### PR TITLE
Convert site to Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+gem 'minimal-mistakes-jekyll'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,194 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.31.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-gist (1.5.0)
+      octokit (~> 4.2)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    minimal-mistakes-jekyll (4.27.2)
+      jekyll (>= 3.7, < 5.0)
+      jekyll-feed (~> 0.1)
+      jekyll-gist (~> 1.5)
+      jekyll-include-cache (~> 0.1)
+      jekyll-paginate (~> 1.1)
+      jekyll-sitemap (~> 1.3)
+    net-http (0.6.0)
+      uri
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.1)
+    rouge (4.6.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.89.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.89.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.89.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    uri (1.0.3)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll
+  minimal-mistakes-jekyll
+
+BUNDLED WITH
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # cello-parts-log
-チェロのパーツ交換について調べた備忘録
+
+チェロのパーツ交換について調べた備忘録です。
+
+`docs` ディレクトリ以下に Jekyll (Minimal Mistakes テーマ) を使ったサイトがあります。GitHub Pages のソースを `docs` に設定すると公開できます。
+
+```bash
+bundle install
+bundle exec jekyll serve --source docs
+```

--- a/docs/_bridges/placeholder.md
+++ b/docs/_bridges/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,33 @@
+theme: minimal-mistakes-jekyll
+locale: ja-JP
+title: "チェロパーツログ"
+minimal_mistakes_skin: "air"
+collections:
+  strings:
+    output: true
+  bridges:
+    output: true
+  pegs:
+    output: true
+  fingerboards:
+    output: true
+  endpins:
+    output: true
+  tailpieces:
+    output: true
+  nuts:
+    output: true
+  saddles:
+    output: true
+  soundposts:
+    output: true
+  tailguts:
+    output: true
+plugins:
+  - jekyll-feed
+defaults:
+  - scope:
+      path: ""
+      type: "parts"
+    values:
+      layout: single

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,0 +1,21 @@
+main:
+  - title: "弦"
+    url: /strings/
+  - title: "駒"
+    url: /bridges/
+  - title: "ペグ"
+    url: /pegs/
+  - title: "指板"
+    url: /fingerboards/
+  - title: "エンドピン"
+    url: /endpins/
+  - title: "テールピース"
+    url: /tailpieces/
+  - title: "ナット"
+    url: /nuts/
+  - title: "サドル"
+    url: /saddles/
+  - title: "魂柱"
+    url: /soundposts/
+  - title: "テールコード"
+    url: /tailguts/

--- a/docs/_endpins/placeholder.md
+++ b/docs/_endpins/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_fingerboards/placeholder.md
+++ b/docs/_fingerboards/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">

--- a/docs/_nuts/placeholder.md
+++ b/docs/_nuts/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_pegs/placeholder.md
+++ b/docs/_pegs/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_saddles/placeholder.md
+++ b/docs/_saddles/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_soundposts/placeholder.md
+++ b/docs/_soundposts/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_strings/placeholder.md
+++ b/docs/_strings/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_tailguts/placeholder.md
+++ b/docs/_tailguts/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/_tailpieces/placeholder.md
+++ b/docs/_tailpieces/placeholder.md
@@ -1,0 +1,5 @@
+---
+layout: single
+title: 工事中
+---
+工事中

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -1,0 +1,7 @@
+---
+title: bridges
+layout: collection
+collection: bridges
+entries_layout: grid
+permalink: /bridges/
+---

--- a/docs/endpins.md
+++ b/docs/endpins.md
@@ -1,0 +1,7 @@
+---
+title: endpins
+layout: collection
+collection: endpins
+entries_layout: grid
+permalink: /endpins/
+---

--- a/docs/fingerboards.md
+++ b/docs/fingerboards.md
@@ -1,0 +1,7 @@
+---
+title: fingerboards
+layout: collection
+collection: fingerboards
+entries_layout: grid
+permalink: /fingerboards/
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+---
+layout: single
+title: チェロパーツログ
+---
+
+<div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+<a class="block border p-4 rounded-lg" href="{{ '/strings/' | relative_url }}">弦</a>
+<a class="block border p-4 rounded-lg" href="{{ '/bridges/' | relative_url }}">駒</a>
+<a class="block border p-4 rounded-lg" href="{{ '/pegs/' | relative_url }}">ペグ</a>
+<a class="block border p-4 rounded-lg" href="{{ '/fingerboards/' | relative_url }}">指板</a>
+<a class="block border p-4 rounded-lg" href="{{ '/endpins/' | relative_url }}">エンドピン</a>
+<a class="block border p-4 rounded-lg" href="{{ '/tailpieces/' | relative_url }}">テールピース</a>
+<a class="block border p-4 rounded-lg" href="{{ '/nuts/' | relative_url }}">ナット</a>
+<a class="block border p-4 rounded-lg" href="{{ '/saddles/' | relative_url }}">サドル</a>
+<a class="block border p-4 rounded-lg" href="{{ '/soundposts/' | relative_url }}">魂柱</a>
+<a class="block border p-4 rounded-lg" href="{{ '/tailguts/' | relative_url }}">テールコード</a>
+</div>

--- a/docs/nuts.md
+++ b/docs/nuts.md
@@ -1,0 +1,7 @@
+---
+title: nuts
+layout: collection
+collection: nuts
+entries_layout: grid
+permalink: /nuts/
+---

--- a/docs/pegs.md
+++ b/docs/pegs.md
@@ -1,0 +1,7 @@
+---
+title: pegs
+layout: collection
+collection: pegs
+entries_layout: grid
+permalink: /pegs/
+---

--- a/docs/saddles.md
+++ b/docs/saddles.md
@@ -1,0 +1,7 @@
+---
+title: saddles
+layout: collection
+collection: saddles
+entries_layout: grid
+permalink: /saddles/
+---

--- a/docs/soundposts.md
+++ b/docs/soundposts.md
@@ -1,0 +1,7 @@
+---
+title: soundposts
+layout: collection
+collection: soundposts
+entries_layout: grid
+permalink: /soundposts/
+---

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -1,0 +1,7 @@
+---
+title: strings
+layout: collection
+collection: strings
+entries_layout: grid
+permalink: /strings/
+---

--- a/docs/tailguts.md
+++ b/docs/tailguts.md
@@ -1,0 +1,7 @@
+---
+title: tailguts
+layout: collection
+collection: tailguts
+entries_layout: grid
+permalink: /tailguts/
+---

--- a/docs/tailpieces.md
+++ b/docs/tailpieces.md
@@ -1,0 +1,7 @@
+---
+title: tailpieces
+layout: collection
+collection: tailpieces
+entries_layout: grid
+permalink: /tailpieces/
+---


### PR DESCRIPTION
## Summary
- switch static HTML to a Jekyll site using Minimal Mistakes
- add Tailwind via CDN and header navigation data
- provide placeholder collection pages for each cello part
- document how to build the site

## Testing
- `bundle exec jekyll build --source docs --destination test_site`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688579d841d08320b630d4a499976a5d