### PR TITLE
Fix GitHub Actions build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true
       - run: bundle exec jekyll build --source docs --destination _site
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- use Ruby 3.2 in pages workflow so bundler can install `sass-embedded`

## Testing
- `bundle install --jobs 4`
- `bundle exec jekyll build --source docs --destination _site`

------
https://chatgpt.com/codex/tasks/task_e_6885816269908320aa6ef0fb4c74e165