### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'


### PR DESCRIPTION
## Summary
- update checkout in GitHub Actions workflow to `v4`

## Testing
- `bundle exec jekyll build --source docs --destination _site`


------
https://chatgpt.com/codex/tasks/task_e_68858327315c8320b3bd9c5a5d192d1c