### PR TITLE
Fix baseurl for GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem 'jekyll'
 
 gem 'minimal-mistakes-jekyll'
+gem 'jekyll-include-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-include-cache
   minimal-mistakes-jekyll
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 ```bash
 bundle install
-bundle exec jekyll serve --source docs
+bundle exec jekyll serve --source docs --baseurl "/cello-parts-log"
 ```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,13 @@
-theme: minimal-mistakes-jekyll
+url: "https://arscombinatoria.github.io"
+baseurl: "/cello-parts-log"
+repository: "arscombinatoria/cello-parts-log"
+remote_theme: "mmistakes/minimal-mistakes"
 locale: ja-JP
 title: "チェロパーツログ"
 minimal_mistakes_skin: "air"
+plugins:
+  - jekyll-feed
+  - jekyll-include-cache
 collections:
   strings:
     output: true
@@ -23,8 +29,6 @@ collections:
     output: true
   tailguts:
     output: true
-plugins:
-  - jekyll-feed
 defaults:
   - scope:
       path: ""


### PR DESCRIPTION
## Summary
- configure `baseurl`, `url`, and related settings in `_config.yml`
- add `jekyll-include-cache` gem
- document how to serve site locally with `--baseurl`

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --baseurl "/cello-parts-log"`

------
https://chatgpt.com/codex/tasks/task_e_688583f87f308320b6ce62f1d4b222fe