### PR TITLE
Add build test workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,15 @@
+name: Build Test
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec jekyll build --source docs --destination _site_test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to test Jekyll build on every push

## Testing
- `bundle exec jekyll build --source docs --destination /tmp/test_build`

------
https://chatgpt.com/codex/tasks/task_e_68858556afa88320b7ddc5f44abf8fde