### PR TITLE
Fix layout warnings by using theme gem

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 url: "https://arscombinatoria.github.io"
 baseurl: "/cello-parts-log"
 repository: "arscombinatoria/cello-parts-log"
-remote_theme: "mmistakes/minimal-mistakes"
+theme: "minimal-mistakes-jekyll"
 locale: ja-JP
 title: "チェロパーツログ"
 minimal_mistakes_skin: "air"


### PR DESCRIPTION
## Summary
- update `_config.yml` to use the `minimal-mistakes-jekyll` gem theme instead of `remote_theme`

This resolves missing layout warnings during Jekyll build.

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --destination _site_test`

------
https://chatgpt.com/codex/tasks/task_e_6885865bbed4832092a7ce6e5c4f8ec6