### PR TITLE
Add hero section and typography

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,7 @@ url: "https://arscombinatoria.github.io"
 baseurl: "/cello-parts-log"
 repository: "arscombinatoria/cello-parts-log"
 remote_theme: "mmistakes/minimal-mistakes"
+sass_dir: _sass
 locale: ja-JP
 title: "チェロパーツログ"
 minimal_mistakes_skin: "air"

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,1 +1,6 @@
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Noto+Serif+JP:wght@700&display=swap" rel="stylesheet">
+<style>
+  body { font-family: 'Noto Sans JP', sans-serif; line-height: 1.6; }
+  h1, h2, h3, h4, h5, h6 { font-family: 'Noto Serif JP', serif; }
+</style>

--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -1,0 +1,1 @@
+/* Custom styles */

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,13 @@ layout: single
 title: チェロパーツログ
 ---
 
-<div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+<div class="bg-gray-100 py-12 mb-8 text-center rounded-lg">
+  <h1 class="text-4xl md:text-5xl font-bold mb-4">チェロパーツログ</h1>
+  <p class="text-lg md:text-xl mb-6">チェロのパーツ交換情報をまとめています。</p>
+  <a href="#parts" class="inline-block bg-blue-600 text-white px-6 py-3 rounded-md">パーツ一覧へ</a>
+</div>
+
+<div id="parts" class="grid grid-cols-2 md:grid-cols-3 gap-4">
 <a class="block border p-4 rounded-lg" href="{{ '/strings/' | relative_url }}">弦</a>
 <a class="block border p-4 rounded-lg" href="{{ '/bridges/' | relative_url }}">駒</a>
 <a class="block border p-4 rounded-lg" href="{{ '/pegs/' | relative_url }}">ペグ</a>


### PR DESCRIPTION
## Summary
- add hero section and CTA on home page
- load Google Fonts and set typefaces
- allow custom Sass overrides

## Testing
- `bundle exec jekyll build --source docs`

------
https://chatgpt.com/codex/tasks/task_e_68858614cfa08320bbd1c78b0ff4ccaa