### PR TITLE
Disable greedy navigation

### DIFF
--- a/docs/_includes/masthead.html
+++ b/docs/_includes/masthead.html
@@ -1,0 +1,35 @@
+{% capture logo_path %}{{ site.logo }}{% endcapture %}
+
+<div class="masthead">
+  <div class="masthead__inner-wrap">
+    <div class="masthead__menu">
+      <nav id="site-nav">
+        {% unless logo_path == empty %}
+          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
+        {% endunless %}
+        <a class="site-title" href="{{ '/' | relative_url }}">
+          {{ site.masthead_title | default: site.title | escape_once | strip }}
+          {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle | escape_once | strip }}</span>{% endif %}
+        </a>
+        <ul class="visible-links">
+          {%- for link in site.data.navigation.main -%}
+            <li class="masthead__menu-item">
+              <a
+                href="{{ link.url | relative_url }}"
+                {% if link.description %} title="{{ link.description }}"{% endif %}
+                {% if link.target %} target="{{ link.target }}"{% endif %}
+              >{{ link.title }}</a>
+            </li>
+          {%- endfor -%}
+        </ul>
+        {% if site.search == true %}
+        <button class="search__toggle" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
+          <i class="fas fa-search"></i>
+        </button>
+        {% endif %}
+        {# Removed greedy navigation toggle to always display all menu items #}
+      </nav>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- override Minimal Mistakes masthead
- remove `greedy-nav` markup so navigation items always remain visible

## Testing
- `bundle exec jekyll build --source docs --baseurl "/cello-parts-log"`

------
https://chatgpt.com/codex/tasks/task_e_6885893554288320b3b3e7bb27ac5524