### PR TITLE
Add hero section and custom fonts

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,1 +1,5 @@
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+<link href="{{ '/assets/css/custom.css' | relative_url }}" rel="stylesheet">

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,19 @@
+body {
+  font-family: 'Roboto', sans-serif;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Noto Serif JP', serif;
+}
+
+.btn-primary {
+  background-color: #1e40af;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+}
+
+.btn-primary:hover {
+  background-color: #1e3a8a;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,13 @@ layout: single
 title: チェロパーツログ
 ---
 
-<div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+<div class="bg-gray-100 py-12 text-center">
+  <h1 class="text-3xl md:text-5xl font-bold mb-4">チェロパーツログ</h1>
+  <p class="mb-6">チェロのパーツ交換記録とメモをまとめています。</p>
+  <a href="#parts" class="btn-primary">パーツ一覧へ</a>
+</div>
+
+<div id="parts" class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-8">
 <a class="block border p-4 rounded-lg" href="{{ '/strings/' | relative_url }}">弦</a>
 <a class="block border p-4 rounded-lg" href="{{ '/bridges/' | relative_url }}">駒</a>
 <a class="block border p-4 rounded-lg" href="{{ '/pegs/' | relative_url }}">ペグ</a>


### PR DESCRIPTION
## Summary
- add Google Fonts and custom stylesheet
- implement a Tailwind hero section on the homepage
- style buttons and text in a new CSS file

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --destination _site_test`

------
https://chatgpt.com/codex/tasks/task_e_68858aa59c8c8320bccc0945b8e4705b