### PR TITLE
Enable wide mode

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,4 @@ defaults:
       type: "parts"
     values:
       layout: single
+      classes: wide


### PR DESCRIPTION
## Summary
- set `classes: wide` in `_config.yml` defaults so pages use wide mode automatically

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68859657a51883208b7d6769c2cb40a9