### PR TITLE
Set wide layout for site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,8 @@ defaults:
       type: "parts"
     values:
       layout: single
+      classes: wide
+  - scope:
+      path: ""
+    values:
+      classes: wide


### PR DESCRIPTION
## Summary
- widen all pages by adding `classes: wide` to default config

## Testing
- `bundle exec jekyll build --source docs`

------
https://chatgpt.com/codex/tasks/task_e_6885977690508320bfd649cbf81feb75