### PR TITLE
Fix link to manufacturer list

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -17,4 +17,4 @@ permalink: /strings/
 
 ## メーカー一覧
 
-[弦メーカーの一覧はこちら](/strings/manufacturers/)
+[弦メーカーの一覧はこちら]({{ '/strings/manufacturers/' | relative_url }})


### PR DESCRIPTION
## Summary
- fix baseurl for manufacturer list link in `strings.md`

## Testing
- `bundle exec jekyll build --source docs --destination site`


------
https://chatgpt.com/codex/tasks/task_e_68860ae404988320918d3cee63077ce1