### PR TITLE
Switch to Awesome Jekyll Theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 
-gem 'minimal-mistakes-jekyll'
+gem 'awesome-jekyll-theme'
+gem 'jekyll-feed'
 gem 'jekyll-include-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,11 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    awesome-jekyll-theme (1.4.2)
+      jekyll (~> 4.3)
+      jekyll-archives (~> 2.3)
+      jekyll-polyglot (~> 1.9)
+      jekyll-seo-tag (~> 2.8.0)
     base64 (0.3.0)
     bigdecimal (3.2.2)
     colorator (1.1.0)
@@ -12,12 +17,6 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.13.4)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -79,17 +78,18 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-archives (2.3.0)
+      jekyll (>= 3.6, < 5.0)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-gist (1.5.0)
-      octokit (~> 4.2)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
+    jekyll-polyglot (1.10.0)
+      jekyll (>= 4.0, >= 3.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
-    jekyll-sitemap (1.4.0)
-      jekyll (>= 3.7, < 5.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.13.1)
@@ -101,20 +101,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
     mercenary (0.4.0)
-    minimal-mistakes-jekyll (4.27.2)
-      jekyll (>= 3.7, < 5.0)
-      jekyll-feed (~> 0.1)
-      jekyll-gist (~> 1.5)
-      jekyll-include-cache (~> 0.1)
-      jekyll-paginate (~> 1.1)
-      jekyll-sitemap (~> 1.3)
-    net-http (0.6.0)
-      uri
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
@@ -156,13 +143,9 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.89.2-x86_64-linux-musl)
       google-protobuf (~> 4.31)
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS
@@ -187,9 +170,10 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  awesome-jekyll-theme
   jekyll
+  jekyll-feed
   jekyll-include-cache
-  minimal-mistakes-jekyll
 
 BUNDLED WITH
    2.6.7

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 チェロのパーツ交換について調べた備忘録です。
 
-`docs` ディレクトリ以下に Jekyll (Minimal Mistakes テーマ) を使ったサイトがあります。GitHub Pages のソースを `docs` に設定すると公開できます。
+`docs` ディレクトリ以下に Jekyll (Awesome Jekyll Theme) を使ったサイトがあります。GitHub Pages のソースを `docs` に設定すると公開できます。
 
 ```bash
 bundle install

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,8 +6,7 @@ locale: ja-JP
 repository: "arscombinatoria/cello-parts-log"
 
 # テーマ＆プラグイン
-theme: "minimal-mistakes-jekyll"
-minimal_mistakes_skin: "air"
+theme: "awesome-jekyll-theme"
 plugins:
   - jekyll-feed
   - jekyll-include-cache
@@ -44,64 +43,5 @@ defaults:
   - scope:
       path: ""
     values:
-      layout: single
-      classes: wide
-      sidebar: false
-      author_profile: false
+      layout: page
 
-  # 各コレクションをグリッド表示
-  - scope:
-      path: ""
-      type: strings
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: bridges
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: pegs
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: fingerboards
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: endpins
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: tailpieces
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: nuts
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: saddles
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: soundposts
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: tailguts
-    values:
-      entries_layout: grid
-  - scope:
-      path: ""
-      type: string_makers
-    values:
-      entries_layout: grid

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -1,8 +1,7 @@
 ---
 title: bridges
-layout: collection
+layout: page
 collection: bridges
-entries_layout: grid
 permalink: /bridges/
 ---
 

--- a/docs/endpins.md
+++ b/docs/endpins.md
@@ -1,8 +1,7 @@
 ---
 title: endpins
-layout: collection
+layout: page
 collection: endpins
-entries_layout: grid
 permalink: /endpins/
 ---
 

--- a/docs/fingerboards.md
+++ b/docs/fingerboards.md
@@ -1,8 +1,7 @@
 ---
 title: fingerboards
-layout: collection
+layout: page
 collection: fingerboards
-entries_layout: grid
 permalink: /fingerboards/
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: single
+layout: home
 title: チェロパーツログ
 ---
 

--- a/docs/nuts.md
+++ b/docs/nuts.md
@@ -1,8 +1,7 @@
 ---
 title: nuts
-layout: collection
+layout: page
 collection: nuts
-entries_layout: grid
 permalink: /nuts/
 ---
 

--- a/docs/pegs.md
+++ b/docs/pegs.md
@@ -1,8 +1,7 @@
 ---
 title: pegs
-layout: collection
+layout: page
 collection: pegs
-entries_layout: grid
 permalink: /pegs/
 ---
 

--- a/docs/saddles.md
+++ b/docs/saddles.md
@@ -1,8 +1,7 @@
 ---
 title: saddles
-layout: collection
+layout: page
 collection: saddles
-entries_layout: grid
 permalink: /saddles/
 ---
 

--- a/docs/soundposts.md
+++ b/docs/soundposts.md
@@ -1,8 +1,7 @@
 ---
 title: soundposts
-layout: collection
+layout: page
 collection: soundposts
-entries_layout: grid
 permalink: /soundposts/
 ---
 

--- a/docs/strings-manufacturers.md
+++ b/docs/strings-manufacturers.md
@@ -1,8 +1,7 @@
 ---
 title: "メーカー一覧"
-layout: collection
+layout: page
 collection: string_makers
-entries_layout: grid
 permalink: /strings/manufacturers/
 ---
 

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -1,8 +1,7 @@
 ---
 title: strings
-layout: collection
+layout: page
 collection: strings
-entries_layout: grid
 permalink: /strings/
 ---
 

--- a/docs/tailguts.md
+++ b/docs/tailguts.md
@@ -1,8 +1,7 @@
 ---
 title: tailguts
-layout: collection
+layout: page
 collection: tailguts
-entries_layout: grid
 permalink: /tailguts/
 ---
 

--- a/docs/tailpieces.md
+++ b/docs/tailpieces.md
@@ -1,8 +1,7 @@
 ---
 title: tailpieces
-layout: collection
+layout: page
 collection: tailpieces
-entries_layout: grid
 permalink: /tailpieces/
 ---
 


### PR DESCRIPTION
## Summary
- replace Minimal Mistakes with Awesome Jekyll Theme and add jekyll-feed plugin
- simplify Jekyll configuration and default layout
- update pages and documentation for new theme

## Testing
- `bundle exec jekyll build --source docs`


------
https://chatgpt.com/codex/tasks/task_e_688db06a5ed8832081a37c4a19df4cae