### PR TITLE
Fix front page links

### DIFF
--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -6,7 +6,11 @@ export default function Page({ title, contentHtml }) {
     <main>
       <h1>{title}</h1>
       <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
-      <p><Link href="/">トップへ戻る</Link></p>
+      <p>
+        <Link href="/" legacyBehavior>
+          <a>トップへ戻る</a>
+        </Link>
+      </p>
     </main>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,9 @@ export default function Home() {
       <p>チェロの各パーツについて、交換や調整の参考になりそうな情報をLLMを使ってWebで調べた内容からまとめています。</p>
       <div className="grid">
         {links.map(link => (
-          <Link key={link.href} href={link.href}>{link.label}</Link>
+          <Link key={link.href} href={link.href} legacyBehavior>
+            <a>{link.label}</a>
+          </Link>
         ))}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- wrap `next/link` usage in `<a>` to render functional anchors
- ensure dynamic pages also provide proper anchor link back to home

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dfc5a69b8832081d0294d758b9252