### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,7 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - run: touch out/.nojekyll
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,10 @@
+const repoName = 'cello-parts-log';
+const isProd = process.env.NODE_ENV === 'production';
+
 const nextConfig = {
   output: 'export',
+  basePath: isProd ? `/${repoName}` : '',
+  assetPrefix: isProd ? `/${repoName}/` : '',
 };
+
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure Next.js export honors repository subpath
- include `.nojekyll` in Pages deploy to preserve `_next`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dfdff74688320b3c2c68cad77f6b8