### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/content/strings/index.md
+++ b/content/strings/index.md
@@ -17,4 +17,4 @@ permalink: /strings/
 
 ## メーカー一覧
 
-[弦メーカーの一覧はこちら](/strings/manufacturers/)
+[弦メーカーの一覧はこちら](./manufacturers/)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,11 @@
-const repoName = 'cello-parts-log';
+const repo = 'cello-parts-log';
 const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig = {
   output: 'export',
-  basePath: isProd ? `/${repoName}` : '',
-  assetPrefix: isProd ? `/${repoName}/` : '',
+  basePath: isProd ? `/${repo}` : '',
+  assetPrefix: isProd ? `/${repo}/` : '',
+  images: { unoptimized: true },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure Next.js builds for GitHub Pages with basePath and assetPrefix
- make internal string manufacturer link relative

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e080407a08320864fdcb30186533f