### PR TITLE
Fix navigation to string manufacturers

### DIFF
--- a/content/strings/index.md
+++ b/content/strings/index.md
@@ -17,4 +17,4 @@ permalink: /strings/
 
 ## メーカー一覧
 
-[弦メーカーの一覧はこちら](./manufacturers/)
+[弦メーカーの一覧はこちら](strings/manufacturers/)

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,6 @@ const links = [
   { href: '/saddles', label: 'サドル' },
   { href: '/soundposts', label: '魂柱' },
   { href: '/tailguts', label: 'テールコード' },
-  { href: '/strings/manufacturers', label: '弦メーカー一覧' },
 ];
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- remove string manufacturer list from top-level navigation
- fix relative link to string manufacturer list so it works on GitHub Pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0e93bdb083208a735cfbacbf8eb9