### PR TITLE
fix: ensure internal links honor base path

### DIFF
--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -7,9 +7,7 @@ export default function Page({ title, contentHtml }) {
       <h1>{title}</h1>
       <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
       <p>
-        <Link href="/" legacyBehavior>
-          <a>トップへ戻る</a>
-        </Link>
+        <Link href="/">トップへ戻る</Link>
       </p>
     </main>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,8 +21,8 @@ export default function Home() {
       <p>チェロの各パーツについて、交換や調整の参考になりそうな情報をLLMを使ってWebで調べた内容からまとめています。</p>
       <div className="grid">
         {links.map(link => (
-          <Link key={link.href} href={link.href} legacyBehavior>
-            <a>{link.label}</a>
+          <Link key={link.href} href={link.href}>
+            {link.label}
           </Link>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- use Next.js `Link` without `legacyBehavior` to automatically prepend the repository base path
- confirm static export config for GitHub Pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0ec2f38083208c694128637cd4ec