### PR TITLE
Add links to string manufacturers

### DIFF
--- a/content/strings/manufacturers/index.md
+++ b/content/strings/manufacturers/index.md
@@ -7,3 +7,6 @@ permalink: /strings/manufacturers/
 ---
 
 弦メーカーに関する情報をまとめます。
+
+- [ヤーガー](jargar/)
+- [ラーセン](larsen/)


### PR DESCRIPTION
## Summary
- Link Jargar and Larsen string manufacturer pages from the manufacturer index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e11136b548320bd27a72045b037b9