### PR TITLE
fix: use relative link for manufacturers

### DIFF
--- a/content/strings/index.md
+++ b/content/strings/index.md
@@ -17,4 +17,4 @@ permalink: /strings/
 
 ## メーカー一覧
 
-[弦メーカーの一覧はこちら](strings/manufacturers/)
+[弦メーカーの一覧はこちら](./manufacturers/)


### PR DESCRIPTION
## Summary
- fix broken link to string manufacturers by using a relative path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e11edb27083209969fbc847daec51