### PR TITLE
Switch site to Dinky Jekyll theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-
-gem 'minimal-mistakes-jekyll'
-gem 'jekyll-include-cache'
+gem 'jekyll-theme-dinky'
+gem 'jekyll-feed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,6 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.13.4)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -81,15 +75,13 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-gist (1.5.0)
-      octokit (~> 4.2)
-    jekyll-include-cache (0.2.1)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
-    jekyll-sitemap (1.4.0)
-      jekyll (>= 3.7, < 5.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-theme-dinky (0.2.0)
+      jekyll (> 3.5, < 5.0)
+      jekyll-seo-tag (~> 2.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.13.1)
@@ -101,20 +93,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
     mercenary (0.4.0)
-    minimal-mistakes-jekyll (4.27.2)
-      jekyll (>= 3.7, < 5.0)
-      jekyll-feed (~> 0.1)
-      jekyll-gist (~> 1.5)
-      jekyll-include-cache (~> 0.1)
-      jekyll-paginate (~> 1.1)
-      jekyll-sitemap (~> 1.3)
-    net-http (0.6.0)
-      uri
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
@@ -156,13 +135,9 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.89.2-x86_64-linux-musl)
       google-protobuf (~> 4.31)
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS
@@ -188,8 +163,8 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
-  jekyll-include-cache
-  minimal-mistakes-jekyll
+  jekyll-feed
+  jekyll-theme-dinky
 
 BUNDLED WITH
    2.6.7

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 チェロのパーツ交換についての備忘録です。
 
-`docs` ディレクトリ以下に Jekyll (Minimal Mistakes テーマ) を使ったサイトがあります。GitHub Pages のソースを `docs` に設定すると公開できます。
+`docs` ディレクトリ以下に Jekyll (Dinky テーマ) を使ったサイトがあります。GitHub Pages のソースを `docs` に設定すると公開できます。
 
 ```bash
 bundle install

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,11 +6,9 @@ locale: ja-JP
 repository: "arscombinatoria/cello-parts-log"
 
 # テーマ＆プラグイン
-theme: "minimal-mistakes-jekyll"
-minimal_mistakes_skin: "air"
+theme: "jekyll-theme-dinky"
 plugins:
   - jekyll-feed
-  - jekyll-include-cache
 
 # コレクション定義
 collections:
@@ -44,10 +42,7 @@ defaults:
   - scope:
       path: ""
     values:
-      layout: single
-      classes: wide
-      sidebar: false
-      author_profile: false
+      layout: default
 
   # 各コレクションをグリッド表示
   - scope:


### PR DESCRIPTION
## Summary
- replace Minimal Mistakes with Dinky theme
- drop Minimal Mistakes configuration
- update README to reflect new theme

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --baseurl "/cello-parts-log"`


------
https://chatgpt.com/codex/tasks/task_e_688ea931e0a88320abb4c0216d58f127