### PR TITLE
Configure defaults and layout overrides

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,14 +40,22 @@ collections:
 
 # Front Matter Defaults
 defaults:
-  # 全ページ共通設定
   - scope:
       path: ""
+      type: pages
     values:
       layout: single
-      classes: wide
-      sidebar: false
       author_profile: false
+      sidebar: null
+      classes: wide
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
 
   # 各コレクションをグリッド表示
   - scope:

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1,0 +1,13 @@
+---
+---
+
+@import "minimal-mistakes/skins/air"; // _config.yml の minimal_mistakes_skin に合わせて変更
+@import "minimal-mistakes";
+
+// 左余白の原因となるサイドバー系を無効化し、本文を全幅化
+.sidebar, .page__related { display: none; }
+.layout--single .page { width: 100%; }
+.page__inner-wrap { margin-left: 0; }
+
+// ナビ下のコンテナが左右に余白を固定化している場合の保険
+.masthead, .page, .initial-content, .site-footer { max-width: none; }


### PR DESCRIPTION
## Summary
- set page and post defaults for wide single layout with no sidebar
- add main stylesheet importing minimal-mistakes skin and removing sidebars

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --destination docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_688eb1825b4883209bf4ee96f8884059