### PR TITLE
Add theme toggle with dark mode support

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ repository: "arscombinatoria/cello-parts-log"
 
 # テーマ＆プラグイン
 theme: "minimal-mistakes-jekyll"
-minimal_mistakes_skin: "air"
+minimal_mistakes_skin: "default"
 plugins:
   - jekyll-feed
   - jekyll-include-cache

--- a/docs/_includes/footer/custom.html
+++ b/docs/_includes/footer/custom.html
@@ -1,0 +1,15 @@
+<button id="theme-toggle" aria-label="Toggle theme">Theme</button>
+<script>
+(function(){
+  var btn=document.getElementById('theme-toggle');
+  btn&&btn.addEventListener('click', function(){
+    var html=document.documentElement, k='theme';
+    var v=html.getAttribute('data-theme');
+    // tri-state: auto(null) -> dark -> light -> auto
+    var next = v===null ? 'dark' : (v==='dark' ? 'light' : null);
+    if(next===null){ html.removeAttribute('data-theme'); localStorage.removeItem(k); }
+    else{ html.setAttribute('data-theme', next); localStorage.setItem(k,next); }
+  });
+})();
+</script>
+

--- a/docs/_includes/head/custom.html
+++ b/docs/_includes/head/custom.html
@@ -1,0 +1,9 @@
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<script>
+(function(){
+  var k='theme';
+  var v=localStorage.getItem(k); // 'light' | 'dark' | null(auto)
+  if(v){ document.documentElement.setAttribute('data-theme', v); }
+})();
+</script>
+

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,1 +1,0 @@
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1,0 +1,19 @@
+---
+---
+@import "minimal-mistakes";
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mm-text-color: #e6e6e6;
+    --mm-bg-color: #111;
+    --mm-link-color: #9ecbff;
+  }
+  body { color: var(--mm-text-color); background: var(--mm-bg-color); }
+  a { color: var(--mm-link-color); }
+}
+
+:root[data-theme="dark"] { color-scheme: dark; }
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] body { background:#111; color:#e6e6e6; }
+:root[data-theme="light"] body { background:#fff; color:#222; }
+


### PR DESCRIPTION
## Summary
- implement theme toggle using data-theme and localStorage
- override styles for dark mode and manual light/dark selections
- set Minimal Mistakes skin to default

## Testing
- `bundle install`
- `bundle exec jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_688eb1bafff08320af59ae2252692361