### PR TITLE
chore: apply layout defaults to collections

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -62,54 +62,98 @@ defaults:
       path: ""
       type: strings
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: bridges
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: pegs
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: fingerboards
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: endpins
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: tailpieces
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: nuts
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: saddles
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: soundposts
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: tailguts
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid
   - scope:
       path: ""
       type: string_makers
     values:
+      layout: single
+      author_profile: false
+      sidebar: null
+      classes: wide
       entries_layout: grid


### PR DESCRIPTION
## Summary
- ensure all content types (strings, bridges, etc.) default to the single, wide layout without sidebars

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --destination docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_688ebcc6f7788320936b6b8e78d2c42a