### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ repository: "arscombinatoria/cello-parts-log"
 
 # テーマ＆プラグイン
 theme: "minimal-mistakes-jekyll"
-minimal_mistakes_skin: "air"
+minimal_mistakes_skin: "default"
 plugins:
   - jekyll-feed
   - jekyll-include-cache

--- a/docs/_includes/footer/custom.html
+++ b/docs/_includes/footer/custom.html
@@ -1,0 +1,14 @@
+<button id="theme-toggle" aria-label="Toggle theme">Theme</button>
+<script>
+(function(){
+  var btn=document.getElementById('theme-toggle');
+  btn&&btn.addEventListener('click', function(){
+    var html=document.documentElement, k='theme';
+    var v=html.getAttribute('data-theme');
+    // tri-state: auto(null) -> dark -> light -> auto
+    var next = v===null ? 'dark' : (v==='dark' ? 'light' : null);
+    if(next===null){ html.removeAttribute('data-theme'); localStorage.removeItem(k); }
+    else{ html.setAttribute('data-theme', next); localStorage.setItem(k,next); }
+  });
+})();
+</script>

--- a/docs/_includes/head/custom.html
+++ b/docs/_includes/head/custom.html
@@ -1,0 +1,8 @@
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<script>
+(function(){
+  var k='theme';
+  var v=localStorage.getItem(k); // 'light' | 'dark' | null(auto)
+  if(v){ document.documentElement.setAttribute('data-theme', v); }
+})();
+</script>

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import "minimal-mistakes/skins/air"; // _config.yml の minimal_mistakes_skin に合わせて変更
+@import "minimal-mistakes/skins/default"; // _config.yml の minimal_mistakes_skin に合わせて変更
 @import "minimal-mistakes";
 
 // 左余白の原因となるサイドバー系を無効化し、本文を全幅化
@@ -11,3 +11,18 @@
 
 // ナビ下のコンテナが左右に余白を固定化している場合の保険
 .masthead, .page, .initial-content, .site-footer { max-width: none; }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mm-text-color: #e6e6e6;
+    --mm-bg-color: #111;
+    --mm-link-color: #9ecbff;
+  }
+  body { color: var(--mm-text-color); background: var(--mm-bg-color); }
+  a { color: var(--mm-link-color); }
+}
+
+:root[data-theme="dark"] { color-scheme: dark; }
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] body { background:#111; color:#e6e6e6; }
+:root[data-theme="light"] body { background:#fff; color:#222; }


### PR DESCRIPTION
## Summary
- set Minimal Mistakes skin to `default`
- add CSS variables and data-theme overrides for dark mode
- include theme toggle and initialization scripts

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --destination docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_688ebd04e6b88320a22ec4123d0efc6a