### PR TITLE
style: center markdown table headers

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -11,3 +11,8 @@
 
 // ナビ下のコンテナが左右に余白を固定化している場合の保険
 .masthead, .page, .initial-content, .site-footer { max-width: none; }
+
+// 中央揃え: 全てのテーブルヘッダー
+th {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- center align all table headers in docs

## Testing
- `bundle exec jekyll build --source docs --destination docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_688ed5fca64c83208d343cbae153469e