### PR TITLE
style: enlarge heading hierarchy

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,45 @@
+---
+---
+
+<!doctype html>
+{% include copyright.html %}
+<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+  <head>
+    {% include head.html %}
+    {% include head/custom.html %}
+    <style>
+      h1, h2, h3 {
+        margin-top: 1.5em;
+        font-weight: bold;
+      }
+      h1 { font-size: 2em; }
+      h2 { font-size: 1.6em; }
+      h3 { font-size: 1.3em; }
+    </style>
+  </head>
+
+  <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
+    {% include_cached skip-links.html %}
+    {% include_cached masthead.html %}
+
+    <div class="initial-content">
+      {{ content }}
+      {% include after-content.html %}
+    </div>
+
+    {% if site.search == true %}
+      <div class="search-content">
+        {% include_cached search/search_form.html %}
+      </div>
+    {% endif %}
+
+    <div id="footer" class="page__footer">
+      <footer>
+        {% include footer/custom.html %}
+        {% include_cached footer.html %}
+      </footer>
+    </div>
+
+    {% include scripts.html %}
+  </body>
+</html>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{{ content }}

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -16,3 +16,12 @@
 th {
   text-align: center;
 }
+
+// 見出しの階層を強調
+h1, h2, h3 {
+  margin-top: 1.5em;
+  font-weight: bold;
+}
+h1 { font-size: 2em; }
+h2 { font-size: 1.6em; }
+h3 { font-size: 1.3em; }


### PR DESCRIPTION
## Summary
- increase font size and weight for h1–h3 headings
- add default and post layouts to apply heading styles site-wide

## Testing
- `bundle exec jekyll build --source docs`

------
https://chatgpt.com/codex/tasks/task_e_68974c01b60c8320bc94cacb8d1c88e0