### PR TITLE
Enable automatic table of contents

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,8 @@ repository: "arscombinatoria/cello-parts-log"
 # テーマ＆プラグイン
 theme: "minimal-mistakes-jekyll"
 minimal_mistakes_skin: "air"
+toc: true
+toc_label: "目次"
 plugins:
   - jekyll-feed
   - jekyll-include-cache

--- a/docs/_string_makers/daddario.md
+++ b/docs/_string_makers/daddario.md
@@ -1,5 +1,6 @@
 ---
 title: "D'Addario(ダダリオ)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/jargar.md
+++ b/docs/_string_makers/jargar.md
@@ -1,5 +1,6 @@
 ---
 title: "Jargar(ヤーガー)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/larsen.md
+++ b/docs/_string_makers/larsen.md
@@ -1,5 +1,6 @@
 ---
 title: "Larsen Strings(ラーセン)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/pirastro.md
+++ b/docs/_string_makers/pirastro.md
@@ -1,5 +1,6 @@
 ---
 title: "Pirastro(ピラストロ)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/savarez.md
+++ b/docs/_string_makers/savarez.md
@@ -1,5 +1,6 @@
 ---
 title: "Savarez/Corelli(サバレス/コレリ)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/thomastik-infeld.md
+++ b/docs/_string_makers/thomastik-infeld.md
@@ -1,5 +1,6 @@
 ---
 title: "Thomastik-Infeld(トマスティーク・インフェルト)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/_string_makers/warchal.md
+++ b/docs/_string_makers/warchal.md
@@ -1,5 +1,6 @@
 ---
 title: "Warchal(ワーチャル)"
+toc: true
 ---
 
 ## 基本情報

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -1,5 +1,6 @@
 ---
 title: bridges
+toc: true
 layout: collection
 collection: bridges
 entries_layout: grid

--- a/docs/endpins.md
+++ b/docs/endpins.md
@@ -1,5 +1,6 @@
 ---
 title: endpins
+toc: true
 layout: collection
 collection: endpins
 entries_layout: grid

--- a/docs/fingerboards.md
+++ b/docs/fingerboards.md
@@ -1,5 +1,6 @@
 ---
 title: fingerboards
+toc: true
 layout: collection
 collection: fingerboards
 entries_layout: grid

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: single
+toc: true
 title: チェロのパーツ交換についての備忘録
 ---
 

--- a/docs/nuts.md
+++ b/docs/nuts.md
@@ -1,5 +1,6 @@
 ---
 title: nuts
+toc: true
 layout: collection
 collection: nuts
 entries_layout: grid

--- a/docs/pegs.md
+++ b/docs/pegs.md
@@ -1,5 +1,6 @@
 ---
 title: pegs
+toc: true
 layout: collection
 collection: pegs
 entries_layout: grid

--- a/docs/saddles.md
+++ b/docs/saddles.md
@@ -1,5 +1,6 @@
 ---
 title: saddles
+toc: true
 layout: collection
 collection: saddles
 entries_layout: grid

--- a/docs/soundposts.md
+++ b/docs/soundposts.md
@@ -1,5 +1,6 @@
 ---
 title: soundposts
+toc: true
 layout: collection
 collection: soundposts
 entries_layout: grid

--- a/docs/strings-manufacturers.md
+++ b/docs/strings-manufacturers.md
@@ -1,5 +1,6 @@
 ---
 title: "メーカー一覧"
+toc: true
 layout: collection
 collection: string_makers
 entries_layout: grid

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -1,5 +1,6 @@
 ---
 title: strings
+toc: true
 layout: collection
 collection: strings
 entries_layout: grid

--- a/docs/tailguts.md
+++ b/docs/tailguts.md
@@ -1,5 +1,6 @@
 ---
 title: tailguts
+toc: true
 layout: collection
 collection: tailguts
 entries_layout: grid

--- a/docs/tailpieces.md
+++ b/docs/tailpieces.md
@@ -1,5 +1,6 @@
 ---
 title: tailpieces
+toc: true
 layout: collection
 collection: tailpieces
 entries_layout: grid


### PR DESCRIPTION
## Summary
- display a Table of Contents at the start of every article
- add site-wide TOC configuration and label in Japanese

## Testing
- `bundle exec jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_68974c1ac978832089bd7fe9446540fb