### PR TITLE
Improve responsive layout for manufacturer listing and tables

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -16,3 +16,18 @@
 th {
   text-align: center;
 }
+
+// メーカー一覧のレスポンシブ対応
+// 画面幅600px以下ではカードを1列表示にする
+@media screen and (max-width: 600px) {
+  .entries-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+// 大きなテーブルを横スクロール可能にする
+.page__content table {
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- render manufacturer list as single-column cards on narrow screens
- allow horizontal scrolling for wide tables

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68974c231cd083208f8dcabe5d9a02ce