### PR TITLE
Improve accessibility roles and permalinks

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,1 +1,2 @@
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+<script src="{{ '/assets/js/accessibility.js' | relative_url }}" defer></script>

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -16,3 +16,14 @@
 th {
   text-align: center;
 }
+
+// 視覚的に控えめなパーマリンク表示
+a.headerlink {
+  text-decoration: none;
+  opacity: 0.5;
+  font-size: 0.85em;
+}
+a.headerlink:hover,
+a.headerlink:focus {
+  opacity: 1;
+}

--- a/docs/assets/js/accessibility.js
+++ b/docs/assets/js/accessibility.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('a.headerlink').forEach(link => {
+    link.setAttribute('aria-label', 'Permalink');
+    link.textContent = '#';
+  });
+  document.querySelectorAll('img:not([alt])').forEach(img => {
+    img.setAttribute('alt', '');
+  });
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ title: チェロのパーツ交換についての備忘録
 ---
 
 チェロの各パーツについて、交換や調整の参考になりそうな情報をLLMを使ってWebで調べた内容からまとめています。
-
-<div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+<main role="main">
+<nav role="navigation" class="grid grid-cols-2 md:grid-cols-3 gap-4">
 <a class="block border p-4 rounded-lg" href="{{ '/strings/' | relative_url }}">弦</a>
 <a class="block border p-4 rounded-lg" href="{{ '/bridges/' | relative_url }}">駒</a>
 <a class="block border p-4 rounded-lg" href="{{ '/pegs/' | relative_url }}">ペグ</a>
@@ -16,4 +16,5 @@ title: チェロのパーツ交換についての備忘録
 <a class="block border p-4 rounded-lg" href="{{ '/saddles/' | relative_url }}">サドル</a>
 <a class="block border p-4 rounded-lg" href="{{ '/soundposts/' | relative_url }}">魂柱</a>
 <a class="block border p-4 rounded-lg" href="{{ '/tailguts/' | relative_url }}">テールコード</a>
-</div>
+</nav>
+</main>


### PR DESCRIPTION
## Summary
- add `<main role="main">` and `<nav role="navigation">` wrappers on the home page
- load accessibility helper script to label permalinks and ensure images have alt text
- style header permalinks to appear subtler

## Testing
- `bundle exec jekyll build -s docs -d docs/_site`

------
https://chatgpt.com/codex/tasks/task_e_68974c2e042c83209f49b2d5a0067cee