### PR TITLE
Fix navigation links for parts and manufacturers

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,24 +16,34 @@ plugins:
 collections:
   strings:
     output: true
+    permalink: /strings/:path/
   bridges:
     output: true
+    permalink: /bridges/:path/
   pegs:
     output: true
+    permalink: /pegs/:path/
   fingerboards:
     output: true
+    permalink: /fingerboards/:path/
   endpins:
     output: true
+    permalink: /endpins/:path/
   tailpieces:
     output: true
+    permalink: /tailpieces/:path/
   nuts:
     output: true
+    permalink: /nuts/:path/
   saddles:
     output: true
+    permalink: /saddles/:path/
   soundposts:
     output: true
+    permalink: /soundposts/:path/
   tailguts:
     output: true
+    permalink: /tailguts/:path/
   string_makers:
     output: true
     permalink: /strings/manufacturers/:path/

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,6 +1,9 @@
 main:
   - title: "弦"
     url: /strings/
+    children:
+      - title: "メーカー一覧"
+        url: /strings/manufacturers/
   - title: "駒"
     url: /bridges/
   - title: "ペグ"


### PR DESCRIPTION
## Summary
- add explicit permalinks for each parts collection so generated URLs match navigation
- expose the strings manufacturer list in the main navigation

## Testing
- `bundle install`
- `bundle exec jekyll build -s docs -d docs/_site`


------
https://chatgpt.com/codex/tasks/task_e_68974c34c8fc8320b1f4cb1d4dbd088b