### PR TITLE
fix: collapse empty left sidebar and widen content

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,6 +58,8 @@ defaults:
       author_profile: false
       sidebar: null
       classes: wide
+      footer_scripts:
+        - /assets/js/no-sidebar.js
   - scope:
       path: ""
       type: posts
@@ -66,6 +68,8 @@ defaults:
       author_profile: false
       sidebar: null
       classes: wide
+      footer_scripts:
+        - /assets/js/no-sidebar.js
 
   # 各コレクションをグリッド表示
   - scope:

--- a/docs/_sass/override/_no-sidebar.scss
+++ b/docs/_sass/override/_no-sidebar.scss
@@ -1,0 +1,10 @@
+/* Collapse empty/absent left sidebar in Minimal Mistakes */
+.layout--single .sidebar:empty { display: none; }
+
+/* When there is no sidebar element OR it's empty, use single column */
+@supports selector(.page:has(.sidebar)) {
+  .layout--single .page:not(:has(.sidebar)),
+  .layout--single .page:has(.sidebar:empty) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -42,3 +42,5 @@ h1, h2, h3 {
 h1 { font-size: 2em; }
 h2 { font-size: 1.6em; }
 h3 { font-size: 1.3em; }
+
+@import "override/no-sidebar";

--- a/docs/assets/js/no-sidebar.js
+++ b/docs/assets/js/no-sidebar.js
@@ -1,0 +1,3 @@
+document.querySelectorAll('.sidebar').forEach(el => {
+  if (!el.textContent.trim()) el.remove();
+});


### PR DESCRIPTION
## Summary
- hide empty left sidebar and adjust layout to use full width
- auto-remove empty sidebars with JS and include script by default

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68988eb770308320acec8c5a8b5c42fa