### PR TITLE
Add breadcrumb navigation to site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,8 @@ baseurl: "/cello-parts-log"
 title: "チェロのパーツ交換についての備忘録"
 locale: ja-JP
 repository: "arscombinatoria/cello-parts-log"
+permalink: /:categories/:title/
+breadcrumbs: true
 
 # テーマ＆プラグイン
 theme: "minimal-mistakes-jekyll"

--- a/docs/_data/ui-text.yml
+++ b/docs/_data/ui-text.yml
@@ -1,0 +1,2 @@
+breadcrumb_home_label: "ホーム"
+breadcrumb_separator: "›"

--- a/docs/_includes/head/custom.html
+++ b/docs/_includes/head/custom.html
@@ -1,0 +1,22 @@
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+{%- assign url_base = site.url | append: site.baseurl -%}
+{%- assign crumbs = '' -%}
+{%- assign position = 1 -%}
+{%- assign crumbs = crumbs | append: '{"@type": "ListItem","position": ' | append: position | append: ', "name": "ホーム", "item": "' | append: url_base | append: '/"}' -%}
+{%- assign position = position | plus: 1 -%}
+{%- if page.categories -%}
+  {%- assign cumulative = '' -%}
+  {%- for category in page.categories -%}
+    {%- assign cumulative = cumulative | append: '/' | append: category -%}
+    {%- assign crumbs = crumbs | append: ',{"@type": "ListItem","position": ' | append: position | append: ', "name": "' | append: category | append: '", "item": "' | append: url_base | append: cumulative | append: '/"}' -%}
+    {%- assign position = position | plus: 1 -%}
+  {%- endfor -%}
+{%- endif -%}
+{%- assign crumbs = crumbs | append: ',{"@type": "ListItem","position": ' | append: position | append: ', "name": "' | append: page.title | append: '", "item": "' | append: url_base | append: page.url | append: '"}' -%}
+<script type="application/ld+json">
+{
+ "@context": "https://schema.org",
+ "@type": "BreadcrumbList",
+ "itemListElement": [{{ crumbs }}]
+}
+</script>

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,1 +1,0 @@
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">

--- a/docs/_string_makers/daddario.md
+++ b/docs/_string_makers/daddario.md
@@ -1,5 +1,6 @@
 ---
 title: "D'Addario(ダダリオ)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/jargar.md
+++ b/docs/_string_makers/jargar.md
@@ -1,5 +1,6 @@
 ---
 title: "Jargar(ヤーガー)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/larsen.md
+++ b/docs/_string_makers/larsen.md
@@ -1,5 +1,6 @@
 ---
 title: "Larsen Strings(ラーセン)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/pirastro.md
+++ b/docs/_string_makers/pirastro.md
@@ -1,5 +1,6 @@
 ---
 title: "Pirastro(ピラストロ)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/savarez.md
+++ b/docs/_string_makers/savarez.md
@@ -1,5 +1,6 @@
 ---
 title: "Savarez/Corelli(サバレス/コレリ)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/thomastik-infeld.md
+++ b/docs/_string_makers/thomastik-infeld.md
@@ -1,5 +1,6 @@
 ---
 title: "Thomastik-Infeld(トマスティーク・インフェルト)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/_string_makers/warchal.md
+++ b/docs/_string_makers/warchal.md
@@ -1,5 +1,6 @@
 ---
 title: "Warchal(ワーチャル)"
+categories: [strings, manufacturers]
 ---
 
 ## 基本情報

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -42,3 +42,12 @@ h1, h2, h3 {
 h1 { font-size: 2em; }
 h2 { font-size: 1.6em; }
 h3 { font-size: 1.3em; }
+
+// パンくずのモバイル表示を調整
+.breadcrumbs {
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.breadcrumbs a {
+  text-decoration: none;
+}

--- a/docs/strings-manufacturers.md
+++ b/docs/strings-manufacturers.md
@@ -4,6 +4,7 @@ layout: collection
 collection: string_makers
 entries_layout: grid
 permalink: /strings/manufacturers/
+categories: [strings]
 ---
 
 弦メーカーに関する情報をまとめます。

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -4,6 +4,7 @@ layout: collection
 collection: strings
 entries_layout: grid
 permalink: /strings/
+categories: [strings]
 ---
 
 以下はチェロ弦に使われる主な材質ごとの特徴をまとめた表です。


### PR DESCRIPTION
## Summary
- enable Minimal Mistakes breadcrumbs and category-based permalinks
- style breadcrumbs and localize labels
- add JSON-LD breadcrumb structured data

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs --baseurl "/cello-parts-log"`


------
https://chatgpt.com/codex/tasks/task_e_68988ee349c88320b800f6a13f815490