### PR TITLE
chore: set npm Dependabot schedule to 7-day cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "06:00"
+      interval: "cron"
+      cronjob: "0 6 * * *"
       timezone: "Asia/Tokyo"
     versioning-strategy: increase
     groups:


### PR DESCRIPTION
### Motivation
- GitHub's `schedule.interval: "daily"` runs only on weekdays, so the npm Dependabot job was changed to an explicit cron to ensure updates run every day including weekends while keeping the same timezone.

### Description
- Updated `.github/dependabot.yml` to set the `npm` package-ecosystem schedule to `interval: "cron"` with `cronjob: "0 6 * * *"` and preserved `timezone: "Asia/Tokyo"`, leaving the `github-actions` entry unchanged.

### Testing
- Ran `npm run lint`, `npm test`, and `npm run build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ea71f6bc8320a8cc3785c42f7e77)