### PR TITLE
Fix sidebar position for endpins materials page

### DIFF
--- a/docs/endpins/endpins-materials.md
+++ b/docs/endpins/endpins-materials.md
@@ -4,7 +4,7 @@ title: 材質別の比較
 slug: /endpins/materials
 hide_table_of_contents: true
 displayed_sidebar: endpinsSidebar
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 以下の表は、エンドピンの材質ごとの音響特性をまとめたものです。


### PR DESCRIPTION
### Motivation
- Correct the sidebar ordering in `endpinsSidebar` so that `docs/endpins/index.md` remains `sidebar_position: 1` and `docs/endpins/endpins-materials.md` appears after it, avoiding a duplicate position and ensuring the intended navigation order.

### Description
- Updated front matter in `docs/endpins/endpins-materials.md` to change `sidebar_position` from `1` to `2`.

### Testing
- Ran `npm run lint`, `npm test` (which runs the typecheck), and `npm run build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6955220b483208877ac5d45b25bd2)