### PR TITLE
fix(docs): correct sidebar_position for fingerboards materials page

### DIFF
--- a/docs/fingerboards/fingerboards-materials.md
+++ b/docs/fingerboards/fingerboards-materials.md
@@ -4,7 +4,7 @@ title: 材質別の比較
 hide_table_of_contents: true
 slug: /fingerboards/materials
 displayed_sidebar: fingerboardsSidebar
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 以下は、指板材の代表的な傾向を比較した表です。


### PR DESCRIPTION
### Motivation
- The materials detail page was using `sidebar_position: 1`, which conflicted with the category index (`docs/fingerboards/index.md`) and caused incorrect sidebar ordering, so the position should be `2`.

### Description
- Update `docs/fingerboards/fingerboards-materials.md` front matter to change `sidebar_position: 1` to `sidebar_position: 2` and commit the change.

### Testing
- Ran `npm run lint`, `npm test` (which runs `tsc --noEmit`), and `npm run build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6982b9da08320a2a3ccfeed080599)