### PR TITLE
Normalize sidebar positions for material docs and adjust Larsen strings order

### DIFF
--- a/docs/nuts/nuts-material-trends.md
+++ b/docs/nuts/nuts-material-trends.md
@@ -3,6 +3,7 @@ id: nuts-material-trends
 title: 材質別の比較
 hide_table_of_contents: true
 displayed_sidebar: nutsSidebar
+sidebar_position: 2
 ---
 
 以下では、一般的なナット材の種類ごとの音響傾向をまとめます。

--- a/docs/pegs/pegs-materials.md
+++ b/docs/pegs/pegs-materials.md
@@ -4,7 +4,7 @@ title: 材質別の比較
 hide_table_of_contents: true
 slug: /pegs/materials
 displayed_sidebar: pegsSidebar
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 以下はペグに使われる代表的な素材ごとの音響的な特徴を整理した表です。

--- a/docs/saddles/saddles-material-trends.md
+++ b/docs/saddles/saddles-material-trends.md
@@ -4,6 +4,7 @@ title: 材質別の比較
 hide_table_of_contents: true
 slug: /saddles/material-trends
 displayed_sidebar: saddlesSidebar
+sidebar_position: 2
 ---
 
 以下はチェロのサドル（あご当て側サドル）の材質によって生じるわずかな音色の違いをまとめた表です。

--- a/docs/soundposts/soundposts-materials.md
+++ b/docs/soundposts/soundposts-materials.md
@@ -4,7 +4,7 @@ title: 材質別の比較
 hide_table_of_contents: true
 slug: /soundposts/materials
 displayed_sidebar: soundpostsSidebar
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 以下の表では、一般的な木製魂柱とカーボンファイバー製魂柱の音響的な傾向をまとめています。

--- a/docs/strings/manufacturers/strings-manufacturer-larsen.md
+++ b/docs/strings/manufacturers/strings-manufacturer-larsen.md
@@ -3,7 +3,7 @@ id: strings-manufacturer-larsen
 displayed_sidebar: stringsSidebar
 title: "Larsen Strings (ラーセン)"
 slug: /strings/manufacturers/larsen
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 Larsen Strings のチェロ弦シリーズ比較ページです。ラーセン内でのシリーズ差（定番〜上位）を把握しやすいよう整理しています。

--- a/docs/tailguts/tailguts-materials.md
+++ b/docs/tailguts/tailguts-materials.md
@@ -4,6 +4,7 @@ title: 材質別の比較
 slug: /tailguts/materials
 hide_table_of_contents: true
 displayed_sidebar: tailgutsSidebar
+sidebar_position: 2
 ---
 
 テールコードの材質ごとの特徴を以下にまとめます。

--- a/docs/tailpieces/tailpieces-materials.md
+++ b/docs/tailpieces/tailpieces-materials.md
@@ -4,7 +4,7 @@ title: 材質別の比較
 slug: /tailpieces/materials
 hide_table_of_contents: true
 displayed_sidebar: tailpiecesSidebar
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 以下はチェロのテールピースに使われる主な材質ごとの違いをまとめた表です。


### PR DESCRIPTION
### Motivation

- Ensure consistent navigation order for material comparison pages by setting explicit `sidebar_position` values in frontmatter. 
- Make the strings manufacturer listing order consistent by moving the Larsen entry to the intended position. 
- Improve sidebar presentation so related docs appear together and predictably in the UI.

### Description

- Added or updated the `sidebar_position` frontmatter to `2` for material comparison pages: `docs/nuts/nuts-material-trends.md`, `docs/saddles/saddles-material-trends.md`, `docs/tailguts/tailguts-materials.md`, and `docs/strings/tailpieces/tailpieces-materials.md` (and similar material docs). 
- Changed `sidebar_position` from `1` to `2` for `docs/pegs/pegs-materials.md` and `docs/soundposts/soundposts-materials.md`. 
- Adjusted `sidebar_position` for the Larsen strings page `docs/strings/manufacturers/strings-manufacturer-larsen.md` from `3` to `4`. 
- No content rows or tables were modified aside from frontmatter ordering fields.

### Testing

- Ran the static site build using `yarn build` and the site compiled successfully. 
- Ran linting with `yarn lint` and no frontmatter/style errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f698fb81708320ab9de99595f89324)