### PR TITLE
Fix soundposts sidebar order (set adjustment sidebar_position to 3)

### DIFF
--- a/docs/soundposts/adjustment.md
+++ b/docs/soundposts/adjustment.md
@@ -3,7 +3,7 @@ id: adjustment
 title: 魂柱調整で変わること
 slug: /soundposts/adjustment
 displayed_sidebar: soundpostsSidebar
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## 概要


### PR DESCRIPTION
### Motivation
- Ensure the `adjustment` page appears after the `soundposts-materials` page in the `soundpostsSidebar` navigation by correcting its front-matter ordering.

### Description
- Update the Front Matter `sidebar_position` in `docs/soundposts/adjustment.md` from `2` to `3`, while `docs/soundposts/soundposts-materials.md` remains `2`.

### Testing
- Ran `npm run lint`, `npm test` (which invokes `npm run typecheck` / `tsc --noEmit`), and `npm run build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69cb9dac08320940214ca835e3039)