### PR TITLE
Adjust sidebar ordering for tailpieces docs pages

### DIFF
--- a/docs/tailpieces/tailpieces-adjusters.md
+++ b/docs/tailpieces/tailpieces-adjusters.md
@@ -4,7 +4,7 @@ title: アジャスター（微調整ネジ）の有無でどう変わるか
 slug: /tailpieces/adjusters
 hide_table_of_contents: true
 displayed_sidebar: tailpiecesSidebar
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 現代のチェロでは、4本ともアジャスター付きのテールピースが使われることが一般的です。ただし、アジャスターが付いていれば常に有利、付いていなければ常に音が良い、という単純な話ではありません。違いは主に、調弦のしやすさ、テールピース周辺の重量、アフター長の取りやすさ、異音や接触のリスクに現れます。

--- a/docs/tailpieces/tailpieces-mass-adjustment.md
+++ b/docs/tailpieces/tailpieces-mass-adjustment.md
@@ -4,7 +4,7 @@ title: 質量調整（軽量化・加重）でどう変わるか
 slug: /tailpieces/mass-adjustment
 hide_table_of_contents: true
 displayed_sidebar: tailpiecesSidebar
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 テールピースは、材質や長さだけでなく、質量の増減でも反応が変わることがあります。工房では、裏面を少し削って軽くしたり、可逆的な重りを追加して反応を確かめたりすることがあります。ただし、単純に「軽いほど良い」「重いほど良い」とは言えず、楽器本体、テールコード長、アフター長との組み合わせで最適点が変わります。


### PR DESCRIPTION
### Motivation
- Ensure the tailpieces pages appear in the requested order in the sidebar for easier navigation of related content.

### Description
- Updated front matter `sidebar_position` in `docs/tailpieces/tailpieces-mass-adjustment.md` from `2` to `3`.
- Updated front matter `sidebar_position` in `docs/tailpieces/tailpieces-adjusters.md` from `3` to `4`.
- Left `docs/tailpieces/tailpieces-materials.md` at `sidebar_position: 2` as specified, and committed the changes.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm test` (which triggers `npm run typecheck`) and it completed successfully.
- Ran `npm run build` (Docusaurus build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69d1a38bc83209b3f818f4916e645)