### PR TITLE
Fix sidebar_position for pegs friction-vs-geared page

### DIFF
--- a/docs/pegs/pegs-friction-vs-geared.md
+++ b/docs/pegs/pegs-friction-vs-geared.md
@@ -3,7 +3,7 @@ id: pegs-friction-vs-geared
 title: 摩擦ペグと機械式ペグ
 slug: /pegs/friction-vs-geared
 displayed_sidebar: pegsSidebar
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## 通常のペグ（摩擦ペグ）


### PR DESCRIPTION
### Motivation
- Ensure correct sidebar ordering for the pegs documentation so `pegs-materials` appears at position `2` and `pegs-friction-vs-geared` follows at position `3`.

### Description
- Update the front matter in `docs/pegs/pegs-friction-vs-geared.md` to set `sidebar_position: 3`, leaving `docs/pegs/pegs-materials.md` at `sidebar_position: 2`.

### Testing
- Ran `npm run lint` and it passed.
- Ran `npm test` (which runs the typecheck) and it passed.
- Ran `npm run build` (Docusaurus build) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69d4d67348320a33f3c6246fd43a6)