### PR TITLE
Pin GitHub Actions uses to immutable commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         node-version: ["22", "24"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '24'
           cache: 'npm'
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -17,16 +17,16 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Run ESLint with reviewdog
-        uses: reviewdog/action-eslint@v1
+        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,7 +13,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: markdownlint
         if: steps.changed.outputs.any == 'true'
-        uses: reviewdog/action-markdownlint@v0.26.2
+        uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
           reporter: github-pr-review
           filter_mode: file


### PR DESCRIPTION
### Motivation
- Improve supply-chain security by replacing tag-based Action references with immutable commit SHAs to avoid unexpected upstream tag moves.
- Preserve readability by adding inline comments that indicate the original semantic version (e.g. `# v6.0.0`).

### Description
- Replaced all `uses:` entries in workflows under `.github/workflows` with full commit SHAs and appended original version comments. 
- Files updated: `.github/workflows/ci.yml`, `.github/workflows/deploy-pages.yml`, `.github/workflows/eslint.yml`, and `.github/workflows/markdownlint.yml`. 
- Actions pinned include `actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/upload-pages-artifact`, `actions/deploy-pages`, `reviewdog/action-eslint`, and `reviewdog/action-markdownlint` with the corresponding SHAs. 
- Changes were committed with message `Pin GitHub Actions to full commit SHAs`.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm test` (which runs type checking) and it completed successfully. 
- Ran `npm run build` and the Docusaurus production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb3203e188320a959cc7315e685c5)