### PR TITLE
ci: clarify reviewdog/action-eslint version comment to v1.34.0

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run ESLint with reviewdog
-        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
+        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
### Motivation
- Make the `reviewdog/action-eslint` version comment explicit in the workflow so the pinned action SHA is annotated with a full `v1.x.y` notation for clarity while keeping the SHA pin for supply-chain safety.

### Description
- Updated the comment for `uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96` in `.github/workflows/eslint.yml` from `# v1` to `# v1.34.0` and left the action pinned by commit SHA.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm test` (which executes the typecheck) and it completed successfully.
- Ran `npm run build` and the site build succeeded (note: existing warnings about missing `blogDir` and a webpack critical-dependency warning were observed but are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb94ec09c8320919f32f2b8576cb6)