### PR TITLE
Limit workflow-level permissions and grant pages/id-token to deploy job

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -44,6 +42,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Motivation
- Reduce top-level workflow privileges to `contents: read` and confine `pages: write` and `id-token: write` to the `deploy` job so the `build` job does not receive unnecessary write permissions.

### Description
- Removed `pages: write` and `id-token: write` from workflow-level `permissions` and added `jobs.deploy.permissions` with `pages: write` and `id-token: write`, leaving `build` job with only `contents: read`.

### Testing
- Inspected the updated workflow with `sed -n '1,220p' .github/workflows/deploy-pages.yml` and `nl -ba .github/workflows/deploy-pages.yml | sed -n '1,220p'` and committed the change with `git commit`, all of which succeeded; no automated `npm run lint`, `npm test`, or `npm run build` were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee7b56ad08320b12ebb98f5755c8c)