### PR TITLE
ci: use BASE_REF env in markdownlint changed-files step

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -20,9 +20,11 @@ jobs:
       - name: Collect changed Markdown files
         id: changed
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}"
-          files="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '*.md' '*.mdx' | tr '\n' ' ')"
+          git fetch origin "$BASE_REF"
+          files="$(git diff --name-only "origin/$BASE_REF...HEAD" -- '*.md' '*.mdx' | tr '\n' ' ')"
           if [ -z "$files" ]; then
             echo "any=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
### Motivation
- Expose the pull request base ref to the shell via an environment variable so the `Collect changed Markdown files` step can reference the base branch reliably and avoid embedding GitHub Actions expressions directly inside the shell script.

### Description
- Updated `.github/workflows/markdownlint.yml` to add `env: BASE_REF: ${{ github.base_ref }}` for the `Collect changed Markdown files` step and replaced `
${{ github.base_ref }}` usages in the `run` script with `$BASE_REF`, while preserving the `GITHUB_OUTPUT` contract that emits `any` and `files`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee7b772608320b6b36c7ddf1f48e5)