### PR TITLE
Update audited dependency lockfile (run `npm audit fix` + `npm dedupe`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12410,9 +12410,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -14579,9 +14579,9 @@
       }
     },
     "node_modules/mermaid/node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -20199,9 +20199,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
### Motivation
- Reduce known dependency vulnerabilities by running `npm audit fix` and `npm dedupe` to update transitive resolutions in the lockfile.
- Keep the site buildable and type-checked while attempting to remediate packages with available fixes.

### Description
- Updated `package-lock.json` transitive resolutions, including `http-proxy-middleware` -> `2.0.10`, `mermaid`'s nested `uuid` -> `14.0.1`, and `semver` -> `7.8.5` as a result of `npm audit fix`/`npm dedupe`.
- Performed dependency deduplication with `npm dedupe` to simplify the dependency tree and reduce duplicate packages.
- No source code changes were made; only the lockfile was modified to reflect updated package metadata and integrities.
- Leftover vulnerabilities that require manual review or breaking upgrades remain and are not forced by this change.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm test` (which executes the `tsc --noEmit` typecheck) and it completed successfully.
- Ran `npm run build` (Docusaurus build) which completed successfully and produced the static output.
- Ran `npm audit fix` which updated dependencies but `npm audit` still reports 31 vulnerabilities (30 moderate, 1 high) due to issues with no available non-breaking fixes or fixes that require forced/breaking updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a368e22aa8083209ba550da0be51d46)