### PR TITLE
chore: refresh audited npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16891,9 +16891,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
### Motivation

- Apply available non-breaking security updates reported by `npm audit` and normalize the installed dependency tree with `npm dedupe`.
- Reduce risk from vulnerable transitive dependencies where possible without introducing breaking changes.

### Description

- Ran `npm audit fix` and `npm dedupe` and updated `package-lock.json` accordingly.
- The lockfile change includes bumping `node_modules/nanoid` from `3.3.16` to `3.3.18` and corresponding integrity/resolved fields.
- No source code or package.json version changes were made.

### Testing

- Executed `npm audit fix` and `npm dedupe` successfully. 
- Ran `npm run lint` which passed. 
- Ran `npm test` (which runs `npm run typecheck`) which passed. 
- Ran `npm run build` (Docusaurus build) which completed and generated static files in the `build` directory.
- Note: `npm audit fix` still reports 26 transitive vulnerabilities (6 moderate, 20 high) that cannot be resolved without breaking changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a5c77cca08320a7d062917d42d431)